### PR TITLE
refactor(cli): minor refactor to helper functions and upgrade structopt 0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,7 +2401,7 @@ dependencies = [
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "shrust 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwrap 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2841,6 +2841,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "structopt"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "structopt-derive"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2849,6 +2858,18 @@ dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3967,7 +3988,9 @@ dependencies = [
 "checksum strings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa481ee1bc42fc3df8195f91f7cb43cf8f2b71b48bac40bf5381cfaf7e481f3c"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
+"checksum structopt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "30b3a3e93f5ad553c38b3301c8a0a0cec829a36783f6a0c467fc4bf553a5f5bf"
 "checksum structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
+"checksum structopt-derive 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea692d40005b3ceba90a9fe7a78fa8d4b82b0ce627eebbffc329aab850f3410e"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"

--- a/safe-cli/Cargo.toml
+++ b/safe-cli/Cargo.toml
@@ -38,7 +38,7 @@ serde = "1.0.91"
 serde_json = "1.0.39"
 serde_yaml = "0.8.11"
 shrust = "0.0.7"
-structopt = "0.2.18"
+structopt = "~0.3.5"
 pretty-hex = "0.1.1"
 
 [features]

--- a/safe-cli/cli.rs
+++ b/safe-cli/cli.rs
@@ -27,34 +27,34 @@ use safe_api::{Safe, XorUrlBase};
 
 #[derive(StructOpt, Debug)]
 /// Interact with the SAFE Network
-#[structopt(raw(global_settings = "&[structopt::clap::AppSettings::ColoredHelp]"))]
+#[structopt(global_settings(&[structopt::clap::AppSettings::ColoredHelp]))]
 pub struct CmdArgs {
     /// subcommands
     #[structopt(subcommand)]
     pub cmd: Option<SubCommands>,
     // /// The account's Root Container address
-    // #[structopt(long = "root", raw(global = "true"))]
+    // #[structopt(long = "root", global(true))]
     // root: bool,
     /// Output data serialisation: [json, jsoncompact, yaml]
-    #[structopt(short = "o", long = "output", raw(global = "true"))]
+    #[structopt(short = "o", long = "output", global(true))]
     output_fmt: Option<OutputFmt>,
     /// Sets JSON as output serialisation format (alias of '--output json')
-    #[structopt(long = "json", raw(global = "true"))]
+    #[structopt(long = "json", global(true))]
     output_json: bool,
     // /// Increase output verbosity. (More logs!)
-    // #[structopt(short = "v", long = "verbose", raw(global = "true"))]
+    // #[structopt(short = "v", long = "verbose", global(true))]
     // verbose: bool,
     // /// Enable to query the output via SPARQL eg.
-    // #[structopt(short = "q", long = "query", raw(global = "true"))]
+    // #[structopt(short = "q", long = "query", global(true))]
     // query: Option<String>,
     /// Dry run of command. No data will be written. No coins spent
-    #[structopt(short = "n", long = "dry-run", raw(global = "true"))]
+    #[structopt(short = "n", long = "dry-run", global(true))]
     dry: bool,
     /// Base encoding to be used for XOR-URLs generated. Currently supported: base32z (default), base32 and base64
-    #[structopt(long = "xorurl", raw(global = "true"))]
+    #[structopt(long = "xorurl", global(true))]
     xorurl_base: Option<XorUrlBase>,
     /// Endpoint of the Authenticator daemon where to send requests to. If not provided, https://localhost:33000 is assumed.
-    #[structopt(long = "endpoint", raw(global = "true"))]
+    #[structopt(long = "endpoint", global(true))]
     pub endpoint: Option<String>,
 }
 

--- a/safe-cli/subcommands/files.rs
+++ b/safe-cli/subcommands/files.rs
@@ -6,12 +6,13 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::helpers::{get_from_arg_or_stdin, notice_dry_run, parse_stdin_arg, serialise_output};
+use super::helpers::{
+    get_from_arg_or_stdin, get_from_stdin, notice_dry_run, parse_stdin_arg, serialise_output,
+};
 use super::OutputFmt;
 use prettytable::{format::FormatBuilder, Table};
 use safe_api::{Safe, XorUrl, XorUrlEncoder};
 use std::collections::BTreeMap;
-use std::io::Read;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -49,13 +50,13 @@ pub enum FilesSubCommands {
     Add {
         /// The source file location.  Specify '-' to read from stdin
         #[structopt(
-            parse(from_str = "parse_stdin_arg"),
-            raw(requires_if = "\"\", \"target\""),
-            raw(requires_if = "\"-\", \"target\"")
+            parse(from_str = parse_stdin_arg),
+            requires_if("", "target"),
+            requires_if("-", "target")
         )]
         location: String,
         /// The target FilesContainer to add the source file to, optionally including the destination path (default is '/') and new file name
-        #[structopt(parse(from_str = "parse_stdin_arg"))]
+        #[structopt(parse(from_str = parse_stdin_arg))]
         target: Option<String>,
         /// Automatically update the NRS name to link to the new version of the FilesContainer. This is only allowed if an NRS URL was provided, and if the NRS name is currently linked to a specific version of the FilesContainer
         #[structopt(short = "u", long = "update-nrs")]
@@ -163,45 +164,39 @@ pub fn files_commander(
             force,
         } => {
             // Validate that location and target are not both "", ie stdin.
-            if let Some(ref t) = target {
-                if t == "" && location == "" {
-                    return Err("Cannot read both Location and Target from stdin.".to_string());
-                }
+            let target_url = target.unwrap_or_else(|| "".to_string());
+            if target_url.is_empty() && location.is_empty() {
+                return Err("Cannot read both <location> and <target> from stdin.".to_string());
             }
 
-            let target = get_from_arg_or_stdin(target, None)?;
+            let target_url =
+                get_from_arg_or_stdin(Some(target_url), Some("...awaiting target URl from STDIN"))?;
             if dry_run && OutputFmt::Pretty == output_fmt {
                 notice_dry_run();
             }
 
             let (version, processed_files, _files_map) =
-                // If location is "" then we read data from stdin instead of a file.
-                if location == "" {
-                    let mut buffer = Vec::new();
-                    match std::io::stdin().read_to_end(&mut buffer) {
-                        Ok(_size) => {
-                            // Update the FilesContainer on the Network
-                            safe.files_container_add_from_raw(&buffer, &target, force, update_nrs, dry_run)?
-                        },
-                        Err(e) => return Err(format!("Error reading from stdin. {}", e))
-                    }
-                }
-                else {
+                // If location is empty then we read arg from STDIN, which can still be a safe:// URL
+                if location.is_empty() {
+                    let file_content = get_from_stdin(Some("...awaiting file's content to add from STDIN"))?;
                     // Update the FilesContainer on the Network
-                    safe.files_container_add(&location, &target, force, update_nrs, dry_run)?
+                    safe.files_container_add_from_raw(&file_content, &target_url, force, update_nrs, dry_run)?
+                } else {
+                    // Update the FilesContainer on the Network
+                    safe.files_container_add(&location, &target_url, force, update_nrs, dry_run)?
                 };
 
             // Now let's just print out a list of the files synced/processed
             if OutputFmt::Pretty == output_fmt {
                 let (table, success_count) = gen_processed_files_table(&processed_files);
                 if success_count > 0 {
-                    let url = match XorUrlEncoder::from_url(&target) {
+                    let url = match XorUrlEncoder::from_url(&target_url) {
                         Ok(mut xorurl_encoder) => {
                             xorurl_encoder.set_content_version(Some(version));
                             xorurl_encoder.set_path("");
                             xorurl_encoder.to_string()?
                         }
-                        Err(_) => target,
+                        Err(_) => target_url,
                     };
 
                     println!("FilesContainer updated (version {}): \"{}\"", version, url);
@@ -209,17 +204,17 @@ pub fn files_commander(
                 } else if !processed_files.is_empty() {
                     println!(
                         "No changes were made to FilesContainer (version {}) at \"{}\"",
-                        version, target
+                        version, target_url
                     );
                     table.printstd();
                 } else {
                     println!(
                         "No changes were made to the FilesContainer (version {}) at: \"{}\"",
-                        version, target
+                        version, target_url
                     );
                 }
             } else {
-                print_serialized_output(target, version, processed_files, output_fmt)?;
+                print_serialized_output(target_url, version, processed_files, output_fmt)?;
             }
             Ok(())
         }

--- a/safe-cli/subcommands/helpers.rs
+++ b/safe-cli/subcommands/helpers.rs
@@ -22,20 +22,19 @@ pub fn xorname_to_hex(xorname: &XorName) -> String {
     xorname.0.iter().map(|b| format!("{:02x}", b)).collect()
 }
 
-// Read the target location from the STDIN if is not an arg provided
-pub fn get_from_arg_or_stdin(
-    target_arg: Option<String>,
-    message: Option<&str>,
-) -> Result<String, String> {
-    match target_arg {
+// Read the argument string from the STDIN if is not an arg provided
+pub fn get_from_arg_or_stdin(arg: Option<String>, message: Option<&str>) -> Result<String, String> {
+    match arg {
         Some(ref t) if t.is_empty() => {
             let val = get_from_stdin(message)?;
-            Ok(String::from_utf8_lossy(&val).to_string())
+            Ok(String::from_utf8(val)
+                .map_err(|err| format!("String read from STDIN is invalid: {}", err))?)
         }
         Some(t) => Ok(t),
         None => {
             let val = get_from_stdin(message)?;
-            Ok(String::from_utf8_lossy(&val).to_string())
+            Ok(String::from_utf8(val)
+                .map_err(|err| format!("String read from STDIN is invalid: {}", err))?)
         }
     }
 }

--- a/safe-cli/subcommands/helpers.rs
+++ b/safe-cli/subcommands/helpers.rs
@@ -10,7 +10,7 @@ use super::OutputFmt;
 use log::debug;
 use safe_api::XorName;
 use serde::ser::Serialize;
-use std::io::{self, stdin, stdout, Write};
+use std::io::{stdin, stdout, Read, Write};
 
 // Warn the user about a dry-run being performed
 pub fn notice_dry_run() {
@@ -28,22 +28,27 @@ pub fn get_from_arg_or_stdin(
     message: Option<&str>,
 ) -> Result<String, String> {
     match target_arg {
-        Some(ref t) if t == "" => get_from_stdin(message),
+        Some(ref t) if t.is_empty() => {
+            let val = get_from_stdin(message)?;
+            Ok(String::from_utf8_lossy(&val).to_string())
+        }
         Some(t) => Ok(t),
-        None => get_from_stdin(message),
+        None => {
+            let val = get_from_stdin(message)?;
+            Ok(String::from_utf8_lossy(&val).to_string())
+        }
     }
 }
 
-// Outputs a message and then reads a single line from stdin
-pub fn get_from_stdin(message: Option<&str>) -> Result<String, String> {
+// Outputs a message and then reads from stdin
+pub fn get_from_stdin(message: Option<&str>) -> Result<Vec<u8>, String> {
     let the_message = message.unwrap_or_else(|| "...awaiting data from STDIN stream...");
     println!("{}", &the_message);
-    let mut input = String::new();
-    match io::stdin().read_line(&mut input) {
-        Ok(n) => {
-            debug!("Read ({} bytes) from STDIN: {}", n, input);
-            input.truncate(input.len() - 1);
-            Ok(input)
+    let mut buffer = Vec::new();
+    match std::io::stdin().read_to_end(&mut buffer) {
+        Ok(size) => {
+            debug!("Read ({} bytes) from STDIN", size);
+            Ok(buffer)
         }
         Err(_) => Err("Failed to read from STDIN stream".to_string()),
     }
@@ -95,7 +100,7 @@ pub fn parse_tx_id(src: &str) -> Result<u64, String> {
 
 // converts "-" to "", both of which mean to read from stdin.
 pub fn parse_stdin_arg(src: &str) -> String {
-    if src == "-" || src == "" {
+    if src.is_empty() || src == "-" {
         "".to_string()
     } else {
         src.to_string()

--- a/safe-cli/subcommands/keys.rs
+++ b/safe-cli/subcommands/keys.rs
@@ -55,7 +55,7 @@ pub enum KeysSubCommands {
         #[structopt(long = "to")]
         to: Option<String>,
         /// The transaction ID, a random one will be generated if not provided. A valid TX Id is a number between 0 and 2^64
-        #[structopt(long = "tx-id", parse(try_from_str = "parse_tx_id"))]
+        #[structopt(long = "tx-id", parse(try_from_str = parse_tx_id))]
         tx_id: Option<u64>,
     },
 }

--- a/safe-cli/subcommands/wallet.rs
+++ b/safe-cli/subcommands/wallet.rs
@@ -83,7 +83,7 @@ pub enum WalletSubCommands {
         #[structopt(long = "to")]
         to: Option<String>,
         /// The transaction ID, a random one will be generated if not provided. A valid TX Id is a number between 0 and 2^64
-        #[structopt(long = "tx-id", parse(try_from_str = "parse_tx_id"))]
+        #[structopt(long = "tx-id", parse(try_from_str = parse_tx_id))]
         tx_id: Option<u64>,
     },
     /*#[structopt(name = "sweep")]


### PR DESCRIPTION
@dan-da this PR upgrades structopt, and I was also playing around with the parser but I couldn't get further than where you got to. So I did a minor refactor in the helper functions to read from stdin. I think we can keep this as is for now and see how we can keep evolving it once we try to implement more of reading args from stdin in other commands. 

One thing I noticed is that structopt shows a weird help message in terms of the arguments, it seems the `requires_if` causes that, see the ` <target> [target]` below:
```
$ safe files add -h
safe-files-add 0.6.0
Add a file to an existing FilesContainer on the network

USAGE:
    safe files add [FLAGS] [OPTIONS] <location> <target> [target]
...
```